### PR TITLE
Fix typos in the documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,7 @@ if (CWP_ENABLE_UNIT_TESTS)
 endif()
 
 # Hide ParaDiGM Library symbols into the CWIPI library.
-# This option is not available if a static library is genererated (CWP_ENABLE_STATIC)
+# This option is not available if a static library is generated (CWP_ENABLE_STATIC)
 # -----------------------------------------------------------------------------------
 
 option(CWP_ENABLE_HIDE_PDM_SYMBOLS "Hide PDM symbols" ON)
@@ -309,7 +309,7 @@ CHECK_FUNCTION_EXISTS(vprintf HAVE_VPRINTF)
 CHECK_FUNCTION_EXISTS(snprintf HAVE_SNPRINTF)
 
 #------------------------------------------------------------------------------
-# Check dependecies
+# Check dependencies
 #------------------------------------------------------------------------------
 
 # Check MPI
@@ -424,8 +424,8 @@ if (NOT CWP_ENABLE_EXTERNAL_PDM)
 endif ()
 
 #------------------------------------------------------------------------------
-# Ajout des sources de tous les elements du projet
-# En fonction des top_targets a installer
+# Ajout des sources de tous les elements du project
+# En function des top_targets a installer
 #------------------------------------------------------------------------------
 
 add_subdirectory(script)

--- a/doc/sphinx/source/old_to_new/old_to_new.rst
+++ b/doc/sphinx/source/old_to_new/old_to_new.rst
@@ -19,7 +19,7 @@ Besides, one can select which MPI ranks will be available for CWIPI.
 In summary, since version 1.0 the following additional arguments are required at CWIPI initialization:
    - ``n_code``: the number of codes executed on current MPI rank ;
    - ``code_names``: the list of local code names ;
-   - ``is_active_rank``: this variable indicates whether the current MPI rank will participate in the coupling : if set to 0, it excludes the current MPI rank from the coupling (e.g. depending on the users's code placement stragegy on CPUs). If set to 1, a coupling including interface mesh and fields/parts has to be created for the current MPI rank.
+   - ``is_active_rank``: this variable indicates whether the current MPI rank will participate in the coupling : if set to 0, it excludes the current MPI rank from the coupling (e.g. depending on the users's code placement strategy on CPUs). If set to 1, a coupling including interface mesh and fields/parts has to be created for the current MPI rank.
 
 Create a coupling
 =================

--- a/training/C/01_Introduction/introduction.md
+++ b/training/C/01_Introduction/introduction.md
@@ -63,7 +63,7 @@ This is achieved by not having any specific data structure but by working with s
 
 **CWIPI** has been created in 2009 upon the initiative of Eric Quémerais.
 It has quickly gained traction in the aerospace-defense industry (Safran, ArianGroup...) as well as in the academic world (CERFACS, CORIA...).
-CERFACS is a main contributer and user of the **CWIPI** library. They enabled coupling definition through a Human Machine Interface (HMI) controled by the OpenPALM process.
+CERFACS is a main contributor and user of the **CWIPI** library. They enabled coupling definition through a Human Machine Interface (HMI) controlled by the OpenPALM process.
 This helped increasing the use of **CWIPI**.
 The main attraction is the performance, which is mentioned in articles of similar coupling tools and which prompted the invitation to the ExCALIBUR workshop.
 A part of this work is derived from "Finite Volume Mesh" library (FVM) and its
@@ -237,17 +237,17 @@ Refer to [FindMPI](https://cmake.org/cmake/help/latest/module/FindMPI.html) in t
 <!--
 * Concepts fondamentaux
   * notion de maillage (comme PDM)
-  * principe du couplage : les codes s'échangent des informations au niveau de l'interface entre leurs maillages respectifs
+  * principe du couplage : les codes s'échangent des information au niveau de l'interface entre leurs maillages respectifs
   -> CWIPI only deals with this interface, which can be of dimension 0, 1, 2 or 3.
 
-  * exercice/jeu participatif
+  * exercise/jeu participatif
     But: introduire - les notions fondamentales (Coupling, Mesh, Field)
                     - les "features" (spatial interpolation, ctrl params, communicateurs MPI, TCP)
                     - les améliorations/nouveautés ont motivé la réécriture complète de CWIPI, d'où New API
 
-    1. on pose le pb: on a veut coupler 2 codes => on crée un "environnement" de couplage (Coupling) (un Coupling fait toujours intervenir 2 codes (potentiellement des instances du même solveur), mais on peut avoir un nombre arbitraire de Couplings)
+    1. on pose le pb: on a veut coupler 2 codes => on crée un "environment" de couplage (Coupling) (un Coupling fait toujours intervenir 2 codes (potentiellement des instances du même solveur), mais on peut avoir un nombre arbitraire de Couplings)
     2. on a dit que les codes devaient s'échanger des infos à travers une interface de couplage géométrique, discrétisée dans chaque code par une portion de son maillage => chaque code doit donc définir SA discrétisation (Interface Mesh) (pas de copie du maillage et si un code intervient dans plusieurs Couplings il peut avoir plusieurs Interface meshes)
-    3. quelles sont les informations que les codes doivent s'échanger? Principalement des variables physiques (faire écho aux exemples d'utilisation?) (Field) (les dofs de ces Fields sont associés au Interface mesh et puisque on l'échange, la définition des Fields par les 2 codes couplés doit être cohérente)
+    3. quelles sont les informations que les codes doivent s'échanger? Principalement des variables physiques (faire écho aux examples d'utilisation?) (Field) (les dofs de ces Fields sont associés au Interface mesh et puisque on l'échange, la définition des Fields par les 2 codes couplés doit être cohérente)
     4. On a maintenant toutes les notions nécessaires pour commencer à esquisser le pseudo-code d'un cas de couplage basique : code1 envoie un champ F1 à code2(, code2 envoie un champ F2 à code1)
       -> les participants doivent obtenir un truc du genre:
           0 - (Init CWIPI)
@@ -623,7 +623,7 @@ Solution:
 We haven't yet explained how to launch the coupled codes. Indeed, in a code coupling application multiple codes will be executed with a common world communicator.
 This is done using the following command : `mpirun -n <n1> code1 : -n <n2>  code2`. It is this common world communicator that is provided to **CWIPI** upon initialization.
 **CWIPI** then determines through a split operation on the common world communicator the communicators a each specific code.
-Those are provided as an output of the initialization function of **CWIPI** and refered to as intra-communicators.
+Those are provided as an output of the initialization function of **CWIPI** and referred to as intra-communicators.
 
 Suppose now that each code has been encapsulated in a module, and that we want to be able to supervise the coupling in a single script run in parallel on all or part of processes.
 This time we launch multiples codes within the one unique program. The command to used then is : `mpirun -n <n3> common_script_code1_code2`. This means that both codes run on the same processes.

--- a/training/C/02_Exercise_1/exercise_1.md
+++ b/training/C/02_Exercise_1/exercise_1.md
@@ -120,7 +120,7 @@ First it provides the dimension of the coupling interface.
 For instance, if the solver mesh is a 3D cube but the coupling happens only on a side of the cube, the dimension of the coupling interface is 2D.
 The coupling interface is thus a surface mesh (i.e. `CWP_INTERFACE_SURFACE` in CWIPI).
 In this exercise, the coupling interface is the whole input mesh. What is thus the dimension of the coupling interface?
-This input mesh is partitionned. This has to be mentionned to CWIPI using `CWP_COMM_PAR_WITH_PART`.
+This input mesh is partitioned. This has to be mentioned to CWIPI using `CWP_COMM_PAR_WITH_PART`.
 Note that since we operate but one coupling step in this exercise, the mesh does not change (i.e. `CWP_DYNAMIC_MESH_STATIC`).
 As mentionned in the introduction of this training, from version 1.0 on CWIPI offers several spatial interpolation algorithms.
 In this exercise we use the location algorithm (`CWP_SPATIAL_INTERP_FROM_LOCATION_MESH_LOCATION_OCTREE`) similar to the one offered in version 0.x of CWIPI.

--- a/training/C/02_Exercise_1/exercise_1_sol.md
+++ b/training/C/02_Exercise_1/exercise_1_sol.md
@@ -124,7 +124,7 @@ First it provides the dimension of the coupling interface.
 For instance, if the solver mesh is a 3D cube but the coupling happens only on a side of the cube, the dimension of the coupling interface is 2D.
 The coupling interface is thus a surface mesh (i.e. `CWP_INTERFACE_SURFACE` in CWIPI).
 In this exercise, the coupling interface is the whole input mesh. What is thus the dimension of the coupling interface?
-This input mesh is partitionned. This has to be mentionned to CWIPI using `CWP_COMM_PAR_WITH_PART`.
+This input mesh is partitioned. This has to be mentioned to CWIPI using `CWP_COMM_PAR_WITH_PART`.
 Note that since we operate but one coupling step in this exercise, the mesh does not change (i.e. `CWP_DYNAMIC_MESH_STATIC`).
 As mentionned in the introduction of this training, from version 1.0 on CWIPI offers several spatial interpolation algorithms.
 In this exercise we use the location algorithm (`CWP_SPATIAL_INTERP_FROM_LOCATION_MESH_LOCATION_OCTREE`) similar to the one offered in version 0.x of CWIPI.

--- a/training/Fortran/01_Introduction/introduction.md
+++ b/training/Fortran/01_Introduction/introduction.md
@@ -63,7 +63,7 @@ This is achieved by not having any specific data structure but by working with s
 
 **CWIPI** has been created in 2009 upon the initiative of Eric Quémerais.
 It has quickly gained traction in the aerospace-defense industry (Safran, ArianGroup...) as well as in the academic world (CERFACS, CORIA...).
-CERFACS is a main contributer and user of the **CWIPI** library. They enabled coupling definition through a Human Machine Interface (HMI) controled by the OpenPALM process.
+CERFACS is a main contributor and user of the **CWIPI** library. They enabled coupling definition through a Human Machine Interface (HMI) controlled by the OpenPALM process.
 This helped increasing the use of **CWIPI**.
 The main attraction is the performance, which is mentioned in articles of similar coupling tools and which prompted the invitation to the ExCALIBUR workshop.
 A part of this work is derived from "Finite Volume Mesh" library (FVM) and its
@@ -237,17 +237,17 @@ Refer to [FindMPI](https://cmake.org/cmake/help/latest/module/FindMPI.html) in t
 <!--
 * Concepts fondamentaux
   * notion de maillage (comme PDM)
-  * principe du couplage : les codes s'échangent des informations au niveau de l'interface entre leurs maillages respectifs
+  * principe du couplage : les codes s'échangent des information au niveau de l'interface entre leurs maillages respectifs
   -> CWIPI only deals with this interface, which can be of dimension 0, 1, 2 or 3.
 
-  * exercice/jeu participatif
+  * exercise/jeu participatif
     But: introduire - les notions fondamentales (Coupling, Mesh, Field)
                     - les "features" (spatial interpolation, ctrl params, communicateurs MPI, TCP)
                     - les améliorations/nouveautés ont motivé la réécriture complète de CWIPI, d'où New API
 
-    1. on pose le pb: on a veut coupler 2 codes => on crée un "environnement" de couplage (Coupling) (un Coupling fait toujours intervenir 2 codes (potentiellement des instances du même solveur), mais on peut avoir un nombre arbitraire de Couplings)
+    1. on pose le pb: on a veut coupler 2 codes => on crée un "environment" de couplage (Coupling) (un Coupling fait toujours intervenir 2 codes (potentiellement des instances du même solveur), mais on peut avoir un nombre arbitraire de Couplings)
     2. on a dit que les codes devaient s'échanger des infos à travers une interface de couplage géométrique, discrétisée dans chaque code par une portion de son maillage => chaque code doit donc définir SA discrétisation (Interface Mesh) (pas de copie du maillage et si un code intervient dans plusieurs Couplings il peut avoir plusieurs Interface meshes)
-    3. quelles sont les informations que les codes doivent s'échanger? Principalement des variables physiques (faire écho aux exemples d'utilisation?) (Field) (les dofs de ces Fields sont associés au Interface mesh et puisque on l'échange, la définition des Fields par les 2 codes couplés doit être cohérente)
+    3. quelles sont les informations que les codes doivent s'échanger? Principalement des variables physiques (faire écho aux examples d'utilisation?) (Field) (les dofs de ces Fields sont associés au Interface mesh et puisque on l'échange, la définition des Fields par les 2 codes couplés doit être cohérente)
     4. On a maintenant toutes les notions nécessaires pour commencer à esquisser le pseudo-code d'un cas de couplage basique : code1 envoie un champ F1 à code2(, code2 envoie un champ F2 à code1)
       -> les participants doivent obtenir un truc du genre:
           0 - (Init CWIPI)
@@ -623,7 +623,7 @@ Solution:
 We haven't yet explained how to launch the coupled codes. Indeed, in a code coupling application multiple codes will be executed with a common world communicator.
 This is done using the following command : `mpirun -n <n1> code1 : -n <n2>  code2`. It is this common world communicator that is provided to **CWIPI** upon initialization.
 **CWIPI** then determines through a split operation on the common world communicator the communicators a each specific code.
-Those are provided as an output of the initialization function of **CWIPI** and refered to as intra-communicators.
+Those are provided as an output of the initialization function of **CWIPI** and referred to as intra-communicators.
 
 Suppose now that each code has been encapsulated in a module, and that we want to be able to supervise the coupling in a single script run in parallel on all or part of processes.
 This time we launch multiples codes within the one unique program. The command to used then is : `mpirun -n <n3> common_script_code1_code2`. This means that both codes run on the same processes.

--- a/training/Fortran/02_Exercise_1/exercise_1.md
+++ b/training/Fortran/02_Exercise_1/exercise_1.md
@@ -162,7 +162,7 @@ First it provides the dimension of the coupling interface.
 For instance, if the solver mesh is a 3D cube but the coupling happens only on a side of the cube, the dimension of the coupling interface is 2D.
 The coupling interface is thus a surface mesh (i.e. `CWP_INTERFACE_SURFACE` in CWIPI).
 In this exercise, the coupling interface is the whole input mesh. What is thus the dimension of the coupling interface?
-This input mesh is partitionned. This has to be mentionned to CWIPI using `CWP_COMM_PAR_WITH_PART`.
+This input mesh is partitioned. This has to be mentioned to CWIPI using `CWP_COMM_PAR_WITH_PART`.
 Note that since we operate but one coupling step in this exercise, the mesh does not change (i.e. `CWP_DYNAMIC_MESH_STATIC`).
 As mentionned in the introduction of this training, from version 1.0 on CWIPI offers several spatial interpolation algorithms.
 In this exercise we use the location algorithm (`CWP_SPATIAL_INTERP_FROM_LOCATION_MESH_LOCATION_OCTREE`) similar to the one offered in version 0.x of CWIPI.

--- a/training/Fortran/02_Exercise_1/exercise_1_sol.md
+++ b/training/Fortran/02_Exercise_1/exercise_1_sol.md
@@ -166,7 +166,7 @@ First it provides the dimension of the coupling interface.
 For instance, if the solver mesh is a 3D cube but the coupling happens only on a side of the cube, the dimension of the coupling interface is 2D.
 The coupling interface is thus a surface mesh (i.e. `CWP_INTERFACE_SURFACE` in CWIPI).
 In this exercise, the coupling interface is the whole input mesh. What is thus the dimension of the coupling interface?
-This input mesh is partitionned. This has to be mentionned to CWIPI using `CWP_COMM_PAR_WITH_PART`.
+This input mesh is partitioned. This has to be mentioned to CWIPI using `CWP_COMM_PAR_WITH_PART`.
 Note that since we operate but one coupling step in this exercise, the mesh does not change (i.e. `CWP_DYNAMIC_MESH_STATIC`).
 As mentionned in the introduction of this training, from version 1.0 on CWIPI offers several spatial interpolation algorithms.
 In this exercise we use the location algorithm (`CWP_SPATIAL_INTERP_FROM_LOCATION_MESH_LOCATION_OCTREE`) similar to the one offered in version 0.x of CWIPI.

--- a/training/Python/01_Introduction/introduction.md
+++ b/training/Python/01_Introduction/introduction.md
@@ -63,7 +63,7 @@ This is achieved by not having any specific data structure but by working with s
 
 **CWIPI** has been created in 2009 upon the initiative of Eric Quémerais.
 It has quickly gained traction in the aerospace-defense industry (Safran, ArianGroup...) as well as in the academic world (CERFACS, CORIA...).
-CERFACS is a main contributer and user of the **CWIPI** library. They enabled coupling definition through a Human Machine Interface (HMI) controled by the OpenPALM process.
+CERFACS is a main contributor and user of the **CWIPI** library. They enabled coupling definition through a Human Machine Interface (HMI) controlled by the OpenPALM process.
 This helped increasing the use of **CWIPI**.
 The main attraction is the performance, which is mentioned in articles of similar coupling tools and which prompted the invitation to the ExCALIBUR workshop.
 A part of this work is derived from "Finite Volume Mesh" library (FVM) and its
@@ -237,17 +237,17 @@ Refer to [FindMPI](https://cmake.org/cmake/help/latest/module/FindMPI.html) in t
 <!--
 * Concepts fondamentaux
   * notion de maillage (comme PDM)
-  * principe du couplage : les codes s'échangent des informations au niveau de l'interface entre leurs maillages respectifs
+  * principe du couplage : les codes s'échangent des information au niveau de l'interface entre leurs maillages respectifs
   -> CWIPI only deals with this interface, which can be of dimension 0, 1, 2 or 3.
 
-  * exercice/jeu participatif
+  * exercise/jeu participatif
     But: introduire - les notions fondamentales (Coupling, Mesh, Field)
                     - les "features" (spatial interpolation, ctrl params, communicateurs MPI, TCP)
                     - les améliorations/nouveautés ont motivé la réécriture complète de CWIPI, d'où New API
 
-    1. on pose le pb: on a veut coupler 2 codes => on crée un "environnement" de couplage (Coupling) (un Coupling fait toujours intervenir 2 codes (potentiellement des instances du même solveur), mais on peut avoir un nombre arbitraire de Couplings)
+    1. on pose le pb: on a veut coupler 2 codes => on crée un "environment" de couplage (Coupling) (un Coupling fait toujours intervenir 2 codes (potentiellement des instances du même solveur), mais on peut avoir un nombre arbitraire de Couplings)
     2. on a dit que les codes devaient s'échanger des infos à travers une interface de couplage géométrique, discrétisée dans chaque code par une portion de son maillage => chaque code doit donc définir SA discrétisation (Interface Mesh) (pas de copie du maillage et si un code intervient dans plusieurs Couplings il peut avoir plusieurs Interface meshes)
-    3. quelles sont les informations que les codes doivent s'échanger? Principalement des variables physiques (faire écho aux exemples d'utilisation?) (Field) (les dofs de ces Fields sont associés au Interface mesh et puisque on l'échange, la définition des Fields par les 2 codes couplés doit être cohérente)
+    3. quelles sont les informations que les codes doivent s'échanger? Principalement des variables physiques (faire écho aux examples d'utilisation?) (Field) (les dofs de ces Fields sont associés au Interface mesh et puisque on l'échange, la définition des Fields par les 2 codes couplés doit être cohérente)
     4. On a maintenant toutes les notions nécessaires pour commencer à esquisser le pseudo-code d'un cas de couplage basique : code1 envoie un champ F1 à code2(, code2 envoie un champ F2 à code1)
       -> les participants doivent obtenir un truc du genre:
           0 - (Init CWIPI)
@@ -623,7 +623,7 @@ Solution:
 We haven't yet explained how to launch the coupled codes. Indeed, in a code coupling application multiple codes will be executed with a common world communicator.
 This is done using the following command : `mpirun -n <n1> code1 : -n <n2>  code2`. It is this common world communicator that is provided to **CWIPI** upon initialization.
 **CWIPI** then determines through a split operation on the common world communicator the communicators a each specific code.
-Those are provided as an output of the initialization function of **CWIPI** and refered to as intra-communicators.
+Those are provided as an output of the initialization function of **CWIPI** and referred to as intra-communicators.
 
 Suppose now that each code has been encapsulated in a module, and that we want to be able to supervise the coupling in a single script run in parallel on all or part of processes.
 This time we launch multiples codes within the one unique program. The command to used then is : `mpirun -n <n3> common_script_code1_code2`. This means that both codes run on the same processes.

--- a/training/Python/02_Exercise_1/exercise_1.md
+++ b/training/Python/02_Exercise_1/exercise_1.md
@@ -145,7 +145,7 @@ First it provides the dimension of the coupling interface.
 For instance, if the solver mesh is a 3D cube but the coupling happens only on a side of the cube, the dimension of the coupling interface is 2D.
 The coupling interface is thus a surface mesh (i.e. `INTERFACE_SURFACE` in CWIPI).
 In this exercise, the coupling interface is the whole input mesh. What is thus the dimension of the coupling interface?
-This input mesh is partitionned. This has to be mentionned to CWIPI using `COMM_PAR_WITH_PART`.
+This input mesh is partitioned. This has to be mentioned to CWIPI using `COMM_PAR_WITH_PART`.
 Note that since we operate but one coupling step in this exercise, the mesh does not change (i.e. `DYNAMIC_MESH_STATIC`).
 As mentionned in the introduction of this training, from version 1.0 on CWIPI offers several spatial interpolation algorithms.
 In this exercise we use the location algorithm (`SPATIAL_INTERP_FROM_LOCATION_MESH_LOCATION_OCTREE`) similar to the one offered in version 0.x of CWIPI.

--- a/training/Python/02_Exercise_1/exercise_1_sol.md
+++ b/training/Python/02_Exercise_1/exercise_1_sol.md
@@ -147,7 +147,7 @@ First it provides the dimension of the coupling interface.
 For instance, if the solver mesh is a 3D cube but the coupling happens only on a side of the cube, the dimension of the coupling interface is 2D.
 The coupling interface is thus a surface mesh (i.e. `INTERFACE_SURFACE` in CWIPI).
 In this exercise, the coupling interface is the whole input mesh. What is thus the dimension of the coupling interface?
-This input mesh is partitionned. This has to be mentionned to CWIPI using `COMM_PAR_WITH_PART`.
+This input mesh is partitioned. This has to be mentioned to CWIPI using `COMM_PAR_WITH_PART`.
 Note that since we operate but one coupling step in this exercise, the mesh does not change (i.e. `DYNAMIC_MESH_STATIC`).
 As mentionned in the introduction of this training, from version 1.0 on CWIPI offers several spatial interpolation algorithms.
 In this exercise we use the location algorithm (`SPATIAL_INTERP_FROM_LOCATION_MESH_LOCATION_OCTREE`) similar to the one offered in version 0.x of CWIPI.


### PR DESCRIPTION
Fixes 38 spelling mistakes in the docs, found with `codespell`.

Prose only. No code identifiers, dependency names or proper nouns changed, and anything that was a valid word rather than a misspelling was left alone.